### PR TITLE
Fix headless offline renderer playback

### DIFF
--- a/scripts/ExportRenderer.gd
+++ b/scripts/ExportRenderer.gd
@@ -58,6 +58,8 @@ func _initialize() -> void:
 	svp.add_child(root_node)
 
 	await root_node.ready
+	if root_node.has_method("set_offline_mode"):
+		root_node.call("set_offline_mode", true)
 	_apply_selected_track_entry()
 
 	# Apply settings that depend on the node being ready.
@@ -88,8 +90,8 @@ func _initialize() -> void:
 			var frame_time = root_node.call("get_offline_time_for_frame", i)
 			if typeof(frame_time) == TYPE_FLOAT and frame_time >= 0.0:
 				t = frame_time
-			if root_node.has_method("set_playhead"):
-				root_node.call("set_playhead", t)
+		if root_node.has_method("set_playhead"):
+			root_node.call("set_playhead", t)
 
 			if should_log_frame:
 				print("[ExportRenderer] Awaiting process_frame for frame %d/%d (t=%.3fs)" % [i, frames_total, t])

--- a/scripts/Visualizer.gd
+++ b/scripts/Visualizer.gd
@@ -223,7 +223,8 @@ func _ready() -> void:
 
 	call_deferred("_init_analyzer")
 
-	call_deferred("_init_capture")
+	if !_offline_mode:
+		call_deferred("_init_capture")
 
 	_bind_all_material_textures()
 	_update_aspect()


### PR DESCRIPTION
## Summary
- re-apply offline mode once the scene is ready so deferred initialization respects it
- advance the offline playhead every frame when exporting
- skip audio capture setup whenever the visualizer runs in offline mode

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5375beb20832b9448d324b66e3fc6