### PR TITLE
Fix headless export stalling on frame_post_draw wait

### DIFF
--- a/scripts/ExportRenderer.gd
+++ b/scripts/ExportRenderer.gd
@@ -19,6 +19,7 @@ var save_jpg: bool = false
 var jpg_quality: float = 0.9
 var duration_s: float = 0.0
 var waveform_base: String = ""
+var frame_post_draw_supported: bool = true
 
 # Tracklist overrides for headless mode
 var tracklist_path: String = ""
@@ -33,24 +34,27 @@ func _initialize() -> void:
 	var display_driver := DisplayServer.get_name()
 	var rendering_method := ""
 	var adapter := ""
-	var using_dummy_renderer := false
-	if Engine.has_singleton("RenderingServer"):
-		var rendering_server: Object = Engine.get_singleton("RenderingServer")
-		if rendering_server and rendering_server.has_method("get_rendering_method"):
-			rendering_method = str(rendering_server.call("get_rendering_method"))
+        var using_dummy_renderer := false
+        if Engine.has_singleton("RenderingServer"):
+                var rendering_server: Object = Engine.get_singleton("RenderingServer")
+                if rendering_server and rendering_server.has_method("get_rendering_method"):
+                        rendering_method = str(rendering_server.call("get_rendering_method"))
 		if rendering_server and rendering_server.has_method("get_rendering_device"):
 			var device: Object = rendering_server.call("get_rendering_device")
 			if device and device.has_method("get_device_name"):
 				adapter = str(device.call("get_device_name"))
 	if rendering_method == "":
 		rendering_method = str(ProjectSettings.get_setting("rendering/renderer/rendering_method", ""))
-	if rendering_method == "" or rendering_method == "dummy":
-		using_dummy_renderer = true
-	print("[ExportRenderer] Display driver: %s | Rendering method: %s | Adapter: %s" % [display_driver, rendering_method, adapter])
-	if using_dummy_renderer:
-		var msg := "[ExportRenderer] No usable renderer detected (display driver: %s, rendering method: %s). Run without --headless or supply --rendering-driver opengl3 / use the GL Compatibility renderer." % [display_driver, rendering_method]
-		push_error(msg)
-		print(msg)
+        if rendering_method == "" or rendering_method == "dummy":
+                using_dummy_renderer = true
+        # Godot's headless display driver never emits frame_post_draw, so fall back to
+        # advancing the scene manually in that environment.
+        frame_post_draw_supported = display_driver != "headless"
+        print("[ExportRenderer] Display driver: %s | Rendering method: %s | Adapter: %s" % [display_driver, rendering_method, adapter])
+        if using_dummy_renderer:
+                var msg := "[ExportRenderer] No usable renderer detected (display driver: %s, rendering method: %s). Run without --headless or supply --rendering-driver opengl3 / use the GL Compatibility renderer." % [display_driver, rendering_method]
+                push_error(msg)
+                print(msg)
 		quit(1)
 		return
 
@@ -65,12 +69,14 @@ func _initialize() -> void:
 
 	# Load your scene into the SubViewport
 	var scene_path: String = args.get("scene", "scenes/AudioViz.tscn")
-	root_node = load(scene_path).instantiate()
-	_apply_tracklist_properties(root_node)
+        root_node = load(scene_path).instantiate()
+        _apply_tracklist_properties(root_node)
 
-	# Force offline mode before the node enters the scene tree so _ready() picks it up.
-	if root_node.has_method("set_offline_mode"):
-		root_node.call("set_offline_mode", true)
+        # Force offline mode before the node enters the scene tree so _ready() picks it up.
+        if root_node.has_method("set_offline_mode"):
+                root_node.call("set_offline_mode", true)
+        if root_node.has_method("set_frame_post_draw_supported"):
+                root_node.call("set_frame_post_draw_supported", frame_post_draw_supported)
 
 	var features_path: String = args.get("features", "")
 	if features_path != "" and root_node.has_method("load_features_csv"):
@@ -81,9 +87,11 @@ func _initialize() -> void:
 
 	svp.add_child(root_node)
 
-	await root_node.ready
-	if root_node.has_method("set_offline_mode"):
-		root_node.call("set_offline_mode", true)
+        await root_node.ready
+        if root_node.has_method("set_offline_mode"):
+                root_node.call("set_offline_mode", true)
+        if root_node.has_method("set_frame_post_draw_supported"):
+                root_node.call("set_frame_post_draw_supported", frame_post_draw_supported)
 	_apply_selected_track_entry()
 
 	# Apply settings that depend on the node being ready.
@@ -162,11 +170,11 @@ func _capture_subviewport_image() -> Image:
 	return img
 
 func _await_render_sync() -> void:
-	if Engine.has_singleton("RenderingServer") and RenderingServer.has_signal("frame_post_draw"):
-		await RenderingServer.frame_post_draw
-		return
-	# Fallback: advance one more frame so textures become available
-	await self.process_frame
+        if frame_post_draw_supported and Engine.has_singleton("RenderingServer") and RenderingServer.has_signal("frame_post_draw"):
+                await RenderingServer.frame_post_draw
+                return
+        # Fallback: advance one more frame so textures become available (headless mode)
+        await self.process_frame
 
 func _parse_args() -> void:
 	var raw := OS.get_cmdline_args()

--- a/scripts/Visualizer.gd
+++ b/scripts/Visualizer.gd
@@ -50,6 +50,7 @@ var _wave_tex: ImageTexture
 
 # Offline rendering support
 var _offline_mode: bool = false
+var _frame_post_draw_supported: bool = true  # set by ExportRenderer when running headless
 var _offline_playhead: float = 0.0
 var _offline_features: Array = []              # Array of {"frame": int, "t": float, "level": float, "kick": float, "bands": PackedFloat32Array}
 var _offline_frame_map: Dictionary = {}        # frame index -> feature array index
@@ -294,17 +295,20 @@ func _apply_shader_params(params: Dictionary) -> void:
 				mat.set_shader_parameter(k, v)
 
 func set_offline_mode(enable: bool) -> void:
-	_offline_mode = enable
-	if enable:
-		started = true
-		if player:
+        _offline_mode = enable
+        if enable:
+                started = true
+                if player:
 			player.stop()
 			analyzer = null
 			capture = null
 			_offline_last_index = 0
 			_offline_frame_map.clear()
 	else:
-		_offline_playhead = 0.0
+                _offline_playhead = 0.0
+
+func set_frame_post_draw_supported(enable: bool) -> void:
+        _frame_post_draw_supported = enable
 
 func set_aspect(aspect: float) -> void:
 	if aspect <= 0.0:


### PR DESCRIPTION
## Summary
- detect when the headless display driver is in use and disable waiting for the render thread
- propagate the setting to the visualizer scene so offline captures keep working in headless mode

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e564d40a04832bb5562f058145725e