### PR TITLE
Update offline rendering README for Windows usage

### DIFF
--- a/tools/offline_render/README.md
+++ b/tools/offline_render/README.md
@@ -5,7 +5,7 @@ These helper scripts turn a Godot visualizer scene into a deterministic offline 
 ## 1. Generate feature tracks
 
 ```
-python tools/offline_render/feature_extract.py path/to/track.mp3 --fps 60 --sr 48000 --out tools/offline_render/features.csv
+python tools/offline_render/feature_extract.py path\to\track.mp3 --fps 60 --sr 48000 --out tools/offline_render/features.csv
 ```
 
 This produces:
@@ -16,7 +16,7 @@ This produces:
 ## 2. Export a compact waveform texture (optional but recommended)
 
 ```
-python tools/offline_render/export_waveform.py path/to/track.mp3 --out_base tools/offline_render/waveform_2048
+python tools/offline_render/export_waveform.py path\to\track.mp3 --out_base tools/offline_render/waveform_2048
 ```
 
 This saves a little-endian `waveform_2048.f32` with mono samples and a matching metadata JSON file. The offline renderer feeds this into shaders that expect the live waveform capture texture.
@@ -24,19 +24,23 @@ This saves a little-endian `waveform_2048.f32` with mono samples and a matching 
 ## 3. Render frames headlessly
 
 ```
-Godot_v4.4-stable_linux.x86_64 --headless --path . \
-  --script scripts/ExportRenderer.gd \
-  --scene scenes/AudioViz.tscn \
-  --features tools/offline_render/features.csv \
-  --waveform tools/offline_render/waveform_2048 \
-  --fps 60 --w 1920 --h 1080 \
+Godot_v4.4-stable_win64.exe --headless --path . ^
+  --script scripts/ExportRenderer.gd ^
+  --scene scenes/AudioViz.tscn ^
+  --features tools/offline_render/features.csv ^
+  --waveform tools/offline_render/waveform_2048 ^
+  --tracklist tracklist-vol1.txt ^
+  --track 1 ^
+  --fps 60 --w 1920 --h 1080 ^
   --out export/frames --jpg 1 --quality 0.9
 ```
+
+`--tracklist` points to a plain-text playlist (see the `tracklist-vol*.txt` samples). Use `--track` to select the 1-based entry to render. Omit `--track` to keep the scene's default configuration while still letting the renderer resolve resources from the provided tracklist.
 
 The renderer writes one numbered frame per timestep. Combine them with FFmpeg and mux in the original audio:
 
 ```
-ffmpeg -r 60 -i export/frames/%06d.jpg -i path/to/track.mp3 \
+ffmpeg -r 60 -i export/frames/%06d.jpg -i path\to\track.mp3 \
   -c:v libx264 -pix_fmt yuv420p -c:a copy final_video.mp4
 ```
 


### PR DESCRIPTION
## Summary
- update the offline rendering instructions to reference the Windows headless executable
- document the `--tracklist` and `--track` arguments in the example command
- adjust sample commands to show Windows-style paths

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e68498e85c832b98ba246b8b965eca